### PR TITLE
added option to preserve object acl on copy

### DIFF
--- a/bucket_copy.py
+++ b/bucket_copy.py
@@ -9,7 +9,7 @@ from boto.s3.connection import S3Connection
 AWS_ACCESS_KEY_ID = ""
 AWS_SECRET_ACCESS_KEY = ""
 
-def copy_s3_bucket(SOURCE_BUCKET, DEST_BUCKET, prefix=None, threads=10):
+def copy_s3_bucket(SOURCE_BUCKET, DEST_BUCKET, prefix=None, threads=10, preserve_acl=False):
 	"""
 	Example usage: copy_s3_bucket(SOURCE_BUCKET='my-source-bucket', DEST_BUCKET='my-destination-bucket', prefix='parent/child/dir/', threads=20)
 	"""
@@ -39,7 +39,7 @@ def copy_s3_bucket(SOURCE_BUCKET, DEST_BUCKET, prefix=None, threads=10):
 				pool_sema.acquire()
 				self.status = "%s : Sempahore Acquired, Copy Next" % datetime.datetime.now()
 				try:
-					thread_key.copy(DEST_BUCKET, self.key_name)
+					thread_key.copy(DEST_BUCKET, self.key_name, preserve_acl=preserve_acl)
 					self.status = "%s : Copy Success : %s" % (datetime.datetime.now(), self.key_name)
 				except:
 					self.status = "%s : Copy Error : %s" % (datetime.datetime.now(), sys.exc_info())


### PR DESCRIPTION
turning on the option causes two additional api calls per object (one to get acl, one to set acl)
